### PR TITLE
Fix warnings

### DIFF
--- a/__tests__/TestAwesomizeRead.re
+++ b/__tests__/TestAwesomizeRead.re
@@ -9,7 +9,7 @@ let data =
       toJsonObj([("bar", toJsonObj([("cow", Js.Json.string("moo"))]))]),
     ),
     ("bar", toJsonObj([("baz", Js.Json.string("moo"))])),
-    ("baz", Js.Json.boolean(Js.true_)),
+    ("baz", Js.Json.boolean(true)),
   ]);
 
 describe("Awesomize.Read", () =>

--- a/__tests__/TestAwesomizeResult.re
+++ b/__tests__/TestAwesomizeResult.re
@@ -9,7 +9,7 @@ describe("Awesomize Result", () => {
       Expect.expect(actual) |> Expect.toBe(expected);
     });
     test("getMessage on an empty key", () => {
-      let result = Belt.Map.String.ofArray([|("test", None)|]);
+      let result = Belt.Map.String.fromArray([|("test", None)|]);
       let actual = Awesomize.Result.Error.getMessage("test", result);
       let expected = None;
       Expect.expect(actual) |> Expect.toBe(expected);

--- a/__tests__/TestAwesomizeValidator.re
+++ b/__tests__/TestAwesomizeValidator.re
@@ -141,7 +141,7 @@ describe("Awesomize Validator", () => {
       "should fail when given a boolean",
       () =>
         Awesomize.Validator.requireArray(
-          Some(Js.Json.boolean(Js.true_)),
+          Some(Js.Json.boolean(true)),
           empty,
         ),
       "require_array",
@@ -175,7 +175,7 @@ describe("Awesomize Validator", () => {
     );
     expectFail(
       "should fail when given a boolean",
-      () => notThing(Some(Js.Json.boolean(Js.true_)), empty),
+      () => notThing(Some(Js.Json.boolean(true)), empty),
       "not_string",
     );
     expectFail(
@@ -212,7 +212,7 @@ describe("Awesomize Validator", () => {
     );
     expectFail(
       "should fail when given a boolean",
-      () => not42(Some(Js.Json.boolean(Js.true_)), empty),
+      () => not42(Some(Js.Json.boolean(true)), empty),
       "not_number",
     );
     expectFail(
@@ -246,7 +246,7 @@ describe("Awesomize Validator", () => {
       () => Awesomize.Validator.isString(maybeNumber(42.0), empty),
       "not_string",
     );
-    let failBool = Some(Js.Json.boolean(Js.true_));
+    let failBool = Some(Js.Json.boolean(true));
     expectFail(
       "should fail when giving a boolean",
       () => Awesomize.Validator.isString(failBool, empty),

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "morgan": "^1.9.0",
     "nyc": "^11.6.0",
     "ramda": "^0.25.0"
+  },
+  "dependencies": {
+    "bs-platform": "^3.0.0"
   }
 }

--- a/src/Awesomize.re
+++ b/src/Awesomize.re
@@ -39,7 +39,7 @@ module Compiler = {
       Belt_Array.map(step, fn => fn(input))
       |> Js.Promise.all
       |> Js.Promise.then_(res =>
-           Belt.Map.String.ofArray(res) |> Js.Promise.resolve
+           Belt.Map.String.fromArray(res) |> Js.Promise.resolve
          );
   };
   let resolver = (key, value) => (key, value) |> Js.Promise.resolve;
@@ -170,7 +170,7 @@ module JavaScript = {
         {
           read: convertRead(def##read),
           sanitize: convertScrubber(def##sanitize),
-          validate: Belt.List.ofArray(def##validate),
+          validate: Belt.List.fromArray(def##validate),
           normalize: convertScrubber(def##normalize),
         },
       ),
@@ -183,7 +183,7 @@ type jsInput = JavaScript.t;
 module Awesomize = {
   open Js.Promise;
   let make = array => {
-    let definitionMap = Belt.Map.String.ofArray(array);
+    let definitionMap = Belt.Map.String.fromArray(array);
     let read = Reader.compiler(definitionMap);
     let sanitize = Sanitize.compiler(definitionMap);
     let validate = Validate.compiler(definitionMap);

--- a/src/Awesomize_validator.re
+++ b/src/Awesomize_validator.re
@@ -146,7 +146,7 @@ let recursive = validator => {
   extern(
     (taggedJson, _) =>
       switch (taggedJson) {
-      | Js.Json.JSONArray(a) => a |> Belt_List.ofArray |> awesomizer
+      | Js.Json.JSONArray(a) => a |> Belt_List.fromArray |> awesomizer
       | _ => Js.Promise.resolve(false)
       },
     "invalid_scope",

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,6 +496,10 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
+bs-platform@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"


### PR DESCRIPTION
It appears that some warnings have surfaced due to some recent updates to BuckleScript. I went ahead, and addressed the deprecation warnings. All tests continue to run warning-free.
